### PR TITLE
由于gitlab库更新太多，原有逻辑只能基于1.8.0才能正常使用

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "commander": "latest",
-    "gitlab": "latest",
+    "gitlab": "1.8.0",
     "json-stable-stringify": "latest",
     "nconf": "latest",
     "underscore": "1.7.0"


### PR DESCRIPTION
尝试过改成最新版本的gitlab，需要动的东西太多。